### PR TITLE
Changed $http object to use updated Promise API

### DIFF
--- a/src/angular-external-options.js
+++ b/src/angular-external-options.js
@@ -71,10 +71,9 @@ angular.module('schemaForm').directive('externalOptions', function() {
           };
 
           $http.get(optionSource, { responseType: 'json' })
-            .success(function(data, status) {
-              processOptions(optionSource, data, current);
-            })
-            .error(function(data, status) {
+            .then(function(res, status) {
+              processOptions(optionSource, res.data, current);
+            }, function(res, status) {
               scope.form.options = [];
               scope.form.selectedOption = '';
               sfSelect(scope.form.key, scope.model, scope.form.selectedOption);


### PR DESCRIPTION
Angular 1.6 has removed legacy success() and error() handlers from the $http object. I've updated the code to reflect that change and make the module Angular 1.6 compliant.